### PR TITLE
 Add GDAL Python bindings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: bash
 services: docker
 
 env:
-  - GDAL_VERSION=2.2.1 VARIANT=slim
+  - GDAL_VERSION=2.2.4 VARIANT=slim
 
 script:
   - ./scripts/cibuild

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -5,4 +5,5 @@ ENV GDAL_VERSION=%%GDAL_VERSION%%
 RUN \
       apt-get update \
       && apt-get install -y --no-install-recommends \
-         gdal-bin=${GDAL_VERSION}+*
+         gdal-bin=${GDAL_VERSION}+* \
+         python-gdal=${GDAL_VERSION}+*


### PR DESCRIPTION
GDAL provides a [python script](https://svn.osgeo.org/gdal/trunk/gdal/swig/python/samples/validate_cloud_optimized_geotiff.py) for validating cloud optimized GeoTIFFs. Adding the Python bindings to the container allows us to easily run that and other scripts.

### Testing

```
$ CI=1 GDAL_VERSION=2.2.4 VARIANT=slim ./scripts/cibuild
...
Successfully tagged quay.io/azavea/gdal:2.2.4-slim
$ docker run --rm -it quay.io/azavea/gdal:2.2.4-slim python
Python 2.7.15rc1 (default, Apr 15 2018, 21:51:34)
[GCC 7.3.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import osgeo
>>>
```
