### PR TITLE
Change base image from sid to buster

### DIFF
--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -1,4 +1,4 @@
-FROM debian:sid-slim
+FROM debian:buster-slim
 
 ENV GDAL_VERSION=%%GDAL_VERSION%%
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ This repository contains a collection of templated `Dockerfile` for image varian
 An example of how to use `cibuild` to build and test an image:
 
 ```bash
-$ CI=1 GDAL_VERSION=2.2.1 VARIANT=slim \
+$ CI=1 GDAL_VERSION=2.4.0 VARIANT=slim \
   ./scripts/cibuild
 ```


### PR DESCRIPTION
Changes base image from `debian:sid-slim` to `debian:buster-slim`. At the time `gdal-bin=2.4.0` was only available on `sid`. It has since been moved to the [`buster`](https://packages.debian.org/buster/gdal-bin) release. [`sid`](https://packages.debian.org/sid/gdal-bin) now contains `gdal-bin=3.0.3`.

Resolves #2 

---

**Testing**

* Confirm that the Travis CI build passes: https://travis-ci.org/azavea/docker-gdal/builds/638517834
* Run the `cibuild` script locally: `CI=1 GDAL_VERSION=2.4.0 VARIANT=slim ./scripts/cibuild`
* Verify that the script reports that `GDAL 2.4.0` is the installed version.